### PR TITLE
disallow toString as global function

### DIFF
--- a/src/org/webdsl/dsl/modules/types/string.str
+++ b/src/org/webdsl/dsl/modules/types/string.str
@@ -23,7 +23,8 @@ rules
     StringInterp(_) -> SimpleSort("String")
 
   check-builtin-signature :
-    (_, "toString", []) -> SimpleSort("String")
+    (s1, "toString", []) -> SimpleSort("String")
+    where not(<?None()> s1)
 
 rules //native string operations
 


### PR DESCRIPTION
I found this while looking at built-in functions for the Statix specification, calling `toString()` as a global function (not on an object/variable) causes an error in the java code